### PR TITLE
fix: add build step for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "exports": {
     ".": "./index.js"
   },
-  "files": ["dist"],
-  "types": "dist/index.d.ts",
+  "types": "./index.d.ts",
   "scripts": {
     "build": "tsc",
     "commit": "cz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "exports": {
     ".": "./index.js"
   },
+  "files": ["dist"],
+  "types": "dist/index.d.ts",
   "scripts": {
+    "build": "tsc",
     "commit": "cz",
     "semantic-release": "semantic-release"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "strictNullChecks": false,
         "emitDeclarationOnly": true,
         "declaration": true,
-        "outDir": "./dist",
+        "outDir": "./",
         "removeComments": false
     },
     "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "strictNullChecks": false,
         "emitDeclarationOnly": true,
         "declaration": true,
-        "outDir": "./",
+        "outDir": "./dist",
         "removeComments": false
     },
     "files": [


### PR DESCRIPTION
I **_think_** we need to add the build step to generate the types as they are used in the packages like `@warp-ds/react` and was generated in https://github.com/fabric-ds/css 

https://github.com/fabric-ds/css/blob/next/tsconfig.json#L13