### PR TITLE
fix: change master mentions to main

### DIFF
--- a/.github/workflows/pr-title-linter.yml
+++ b/.github/workflows/pr-title-linter.yml
@@ -7,7 +7,7 @@ on:
       - '*'
       - '*/*'
       - '**'    
-      - '!master'
+      - '!main'
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
       - alpha
 jobs:
   release:

--- a/.github/workflows/update-alpha.yml
+++ b/.github/workflows/update-alpha.yml
@@ -4,7 +4,7 @@ on:
     workflows:
       - Release
     branches:
-      - master
+      - main
     types: completed
 jobs:
   rebase:
@@ -12,9 +12,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Rebase alpha to master
+      - name: Rebase alpha to main
         run: |
             git fetch --unshallow
             git checkout alpha
-            git rebase origin/master
+            git rebase origin/main
             git push

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": [{ "name": "master" }, { "name": "alpha", "prerelease": true }],
+  "branches": [{ "name": "main" }, { "name": "alpha", "prerelease": true }],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ pnpm install
 
 This project uses
 [Semantic Release](https://github.com/semantic-release/semantic-release) to
-automate package publishing when making changes to the `master` or `alpha` branch.
+automate package publishing when making changes to the `main` or `alpha` branch.
 
 It is recommended to branch off the `alpha` branch. Make sure `alpha` branch is 
-updated with the latest `master`. 
+updated with the latest `main`. 
 Follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 when making changes. When your changes are ready for pull request, this should be 
 opened against the `alpha` branch.


### PR DESCRIPTION
The `master` branch has now been renamed to `main` so we need to do some adjustments.