### PR TITLE
fix(alert): remove top pt-4 and add min-w-16 class to alert icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ export const button = {
 
 export const alert = {
   alert: "flex p-16 border border-l-4 rounded-4",
-  icon: "w-16 mr-8 pt-4",
+  icon: "w-16 mr-8",
   negative:  "i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border",
   negativeIcon: "i-text-$color-alert-negative-icon",
   positive:  "i-border-$color-alert-positive-subtle-border i-bg-$color-alert-positive-background i-text-$color-alert-positive-text i-border-l-$color-alert-positive-border",

--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ export const button = {
 
 export const alert = {
   alert: "flex p-16 border border-l-4 rounded-4",
-  icon: "w-16 mr-8",
+  icon: "w-16 mr-8 min-w-16",
   negative:  "i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border",
   negativeIcon: "i-text-$color-alert-negative-icon",
   positive:  "i-border-$color-alert-positive-subtle-border i-bg-$color-alert-positive-background i-text-$color-alert-positive-text i-border-l-$color-alert-positive-border",


### PR DESCRIPTION
- The `pt-4` class was first added in [warp-ds/react](https://github.com/warp-ds/react/commit/9748c5f0f871cd18eb6dc72eb49d2fc3f43d8b55#diff-cf1da5de7911c1111f59f31fe505e6cddb713a4abbc8acb1cc74f1af602050ccR25) but it doesn't look like we need it.

- we can now use `min-w-16` instead of inline `min-width: 16px` in the alert component

Before:
<img width="318" alt="Screenshot 2023-04-05 at 09 58 38" src="https://user-images.githubusercontent.com/41303231/230018356-a46616ad-44dd-42fe-976f-2f2f8bfc1405.png">

After:
<img width="319" alt="Screenshot 2023-04-05 at 09 58 56" src="https://user-images.githubusercontent.com/41303231/230018326-2bce642d-21d8-4e54-88cf-8525b9511337.png">
