### PR TITLE
fix(expandable): move hover for background to expandableBox

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,14 +193,14 @@ export const buttonReset =
 export const expandable = {
   expandable: 'will-change-height',
   expandableTitle: 'i-text-$color-expandable-title-text',
-  expandableBox: 'i-bg-$color-expandable-background py-0 px-0 ' + box.box,
+  expandableBox: 'i-bg-$color-expandable-background hover:i-bg-$color-expandable-background-hover py-0 px-0 ' + box.box,
   expandableBleed: box.bleed,
   chevron: 'inline-block align-middle transform transition-transform transition-gpu i-text-$color-expandable-icon',
   chevronNonBox: 'relative left-8',
   chevronBox: 'absolute right-16',
   chevronExpanded: '-rotate-180',
   button: buttonReset + ' hover:underline focus:underline',
-  buttonBox: 'hover:i-bg-$color-expandable-background-hover w-full text-left relative inline-flex! items-center ' + box.box,
+  buttonBox: 'w-full text-left relative inline-flex! items-center ' + box.box,
 };
 
 /*


### PR DESCRIPTION
On hover, the entire box should change color. 
`buttonBox` is only set on the button instead of the entire component, while `expandableBox` affects the entire box.  

<img width="391" alt="Screenshot 2023-04-19 at 13 42 03" src="https://user-images.githubusercontent.com/6739459/233064335-7a4fa20c-9cd8-4563-b369-58336acccd34.png">
