### PR TITLE
feat: add breadcrumbs component classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,3 +306,10 @@ export const prefix = {
   wrapperWithIcon: 'w-40',
   label: `${label.label} pb-0 text-secondary text-12`,
 };
+
+export const breadcrumbs = {
+  wrapper: 'flex space-x-8',
+  text: 'i-text-$color-breadcrumbs-text',
+  link: 'i-text-$color-breadcrumbs-link-text',
+  separator: 'select-none i-text-$color-breadcrumbs-icon',
+}


### PR DESCRIPTION
This PR includes the following changes:

- apply classes based on tokens from https://github.com/warp-ds/tokens/commit/b240091a6c750b13c1207a65eef93f1a8dcf1506
- unify wrapper classes (in React the wrapper included `space-x-reverse` class to fix a [bug](https://github.com/fabric-ds/react/issues/57), but the bug is gone when wrapper classes are applied to a different element (like in [Warp Vue](https://github.com/warp-ds/vue/blob/alpha/components/breadcrumbs/w-breadcrumbs.vue#L4))

## Example
![Screenshot 2023-04-21 at 09 06 20](https://user-images.githubusercontent.com/41303231/233565520-3c9af080-bc39-4591-a97f-47ad1c555069.png)
