### PR TITLE
feat: add classes for ButtonGroup component 

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,6 +260,24 @@ export const button = {
   a11y: 'sr-only',
 };
 
+export const buttonGroup = {
+  wrapper: 'inline-flex rounded-4 overflow-hidden',
+  raised: 'i-shadow-$shadow-buttongroup',
+  vertical: 'flex-col',
+  nonOutlinedVertical: 'divide-y',
+  nonOutlinedHorizontal: 'divide-x',
+}
+
+export const buttonGroupItem = {
+  wrapper: 'relative i-text-$color-buttongroup-text i-bg-$color-buttongroup-background hover:i-bg-$color-buttongroup-background-hover active:i-border-$color-buttongroup-border-active active:i-text-$color-buttongroup-text-active active:i-bg-$color-buttongroup-background-active',
+  outlined: 'border hover:z-30 i-border-$color-buttongroup-border hover:i-border-$color-buttongroup-border-hover active:i-border-$color-buttongroup-border-active',
+  outlinedVertical: '-mb-1 last:mb-0 first:rounded-lt-4 first:rounded-rt-4 last:rounded-lb-4 last:rounded-rb-4',
+  outlinedHorizontal: '-mr-1 last:mr-0 first:rounded-lt-4 first:rounded-lb-4 last:rounded-rt-4 last:rounded-rb-4',
+  outlinedVerticalResets: 'px-1 pt-1 last:pb-1 -mb-1 last:mb-0',
+  outlinedHorizontalResets: 'py-1 pl-1 last:pr-1 -mr-1 last:mr-0',
+  selected: 'z-30 i-text-$color-buttongroup-text-active! i-bg-$color-buttongroup-background-active! hover:i-bg-$color-buttongroup-background-active-hover! i-border-$color-buttongroup-border-active',
+}
+
 export const alert = {
   alert: "flex p-16 border border-l-4 rounded-4",
   icon: "w-16 mr-8 min-w-16",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@eik/cli": "^2.0.22",
     "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/git": "^10.0.1",
-    "@warp-ds/uno": "^1.0.0-alpha.8",
+    "@warp-ds/uno": "^1.0.0-alpha.18",
     "cz-conventional-changelog": "^3.3.0",
     "semantic-release": "^19.0.5",
     "typescript": "^4.9.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ devDependencies:
     specifier: ^10.0.1
     version: 10.0.1(semantic-release@19.0.5)
   '@warp-ds/uno':
-    specifier: ^1.0.0-alpha.8
-    version: 1.0.0-alpha.8
+    specifier: ^1.0.0-alpha.18
+    version: 1.0.0-alpha.18
   cz-conventional-changelog:
     specifier: ^3.3.0
     version: 3.3.0
@@ -967,8 +967,8 @@ packages:
       - rollup
     dev: true
 
-  /@warp-ds/uno@1.0.0-alpha.8:
-    resolution: {integrity: sha512-OcrvcdtzlDtV+v1qTb6nLdK5xFdZNJDL3txYOvnNBXrmr7Jx7cmiMIRctZxkLsjSLA4HGVo5NlNWakHeWawSmw==}
+  /@warp-ds/uno@1.0.0-alpha.18:
+    resolution: {integrity: sha512-VYhcULCiJjjQIdnWzQzi65T22xDRpFgU6Kp606u797HKgEKpk1oUIZck6ataDHQIVGDpzVp06+EQknSOkrweGQ==}
     dependencies:
       '@unocss/core': 0.50.6
       '@unocss/preset-mini': 0.50.6


### PR DESCRIPTION
These classes are currently applicable only to Vue's ButtonGroup component. Some of them may be reused in `Toggle` component of "radio-button" type, but that would require some more restructuring of that component, as well as modification of the component classes added in this PR. I attempted to reuse these classes in [this @warp-ds/react branch](https://github.com/warp-ds/react/tree/refactor/button-group-style-in-toggle) but decided to leave it for when we have more time to work on alignment between Vue and React components in Warp.

## non-outlined 
### with selected and hovered items
![Screenshot 2023-05-03 at 15 23 02](https://user-images.githubusercontent.com/41303231/235929895-384f01b5-0a15-4aa2-9462-f6ce488f1bf9.png)
### raised with selected item
![Screenshot 2023-05-03 at 15 25 57](https://user-images.githubusercontent.com/41303231/235929906-9740144d-bbab-4fd1-907b-efea7cfe9192.png)
### vertical with selected hovered item
![Screenshot 2023-05-03 at 15 29 51](https://user-images.githubusercontent.com/41303231/235930462-34dc9291-5075-459d-b06c-c94fe2313b9a.png)

## outlined 
### with selected and hovered items
![Screenshot 2023-05-03 at 15 23 25](https://user-images.githubusercontent.com/41303231/235929899-1c304b8c-e5ee-4615-adf1-52f2f0af61b6.png)
### vertical with selected item
![Screenshot 2023-05-03 at 15 25 43](https://user-images.githubusercontent.com/41303231/235929902-e0b89c74-ebd5-4cce-b5a6-e7cdbf561054.png)
### raised & vertical with selected item
![Screenshot 2023-05-03 at 15 25 47](https://user-images.githubusercontent.com/41303231/235929904-f1bcb03f-b864-4b2f-ba58-3dff8bc68248.png)


