### PR TITLE
fix(btngroup): remove active border color token from non-outlined item

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ export const buttonGroup = {
 }
 
 export const buttonGroupItem = {
-  wrapper: 'relative i-text-$color-buttongroup-utility-text i-bg-$color-buttongroup-utility-background hover:i-bg-$color-buttongroup-utility-background-hover active:i-border-$color-buttongroup-utility-border-active active:i-text-$color-buttongroup-utility-text-active active:i-bg-$color-buttongroup-utility-background-active',
+  wrapper: 'relative i-text-$color-buttongroup-utility-text i-bg-$color-buttongroup-utility-background hover:i-bg-$color-buttongroup-utility-background-hover active:i-text-$color-buttongroup-utility-text-active active:i-bg-$color-buttongroup-utility-background-active',
   outlined: 'border hover:z-30 i-border-$color-buttongroup-utility-border hover:i-border-$color-buttongroup-utility-border-hover active:i-border-$color-buttongroup-utility-border-active',
   outlinedVertical: '-mb-1 last:mb-0 first:rounded-lt-4 first:rounded-rt-4 last:rounded-lb-4 last:rounded-rb-4',
   outlinedHorizontal: '-mr-1 last:mr-0 first:rounded-lt-4 first:rounded-lb-4 last:rounded-rt-4 last:rounded-rb-4',


### PR DESCRIPTION
Before:
<img width="205" alt="Screenshot 2023-05-08 at 12 24 08" src="https://user-images.githubusercontent.com/41303231/236800912-b489d91d-a638-4887-bf82-ff2a0690e82e.png">


After:
<img width="215" alt="Screenshot 2023-05-08 at 12 23 59" src="https://user-images.githubusercontent.com/41303231/236800914-3b00b319-a3f6-41c5-88e5-69106ac14183.png">