### PR TITLE
fix(btngroup): remove border-hover and background-active-hover classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,13 +270,13 @@ export const buttonGroup = {
 
 export const buttonGroupItem = {
   wrapper: 'relative i-text-$color-buttongroup-utility-text i-bg-$color-buttongroup-utility-background hover:i-bg-$color-buttongroup-utility-background-hover active:i-text-$color-buttongroup-utility-text-active active:i-bg-$color-buttongroup-utility-background-active',
-  outlined: 'border hover:z-30 i-border-$color-buttongroup-utility-border hover:i-border-$color-buttongroup-utility-border-hover active:i-border-$color-buttongroup-utility-border-active',
+  outlined: 'border hover:z-30 i-border-$color-buttongroup-utility-border active:i-border-$color-buttongroup-utility-border-active',
   outlinedVertical: '-mb-1 last:mb-0 first:rounded-lt-4 first:rounded-rt-4 last:rounded-lb-4 last:rounded-rb-4',
   outlinedHorizontal: '-mr-1 last:mr-0 first:rounded-lt-4 first:rounded-lb-4 last:rounded-rt-4 last:rounded-rb-4',
   outlinedVerticalResets: 'px-1 pt-1 last:pb-1 -mb-1 last:mb-0',
   outlinedHorizontalResets: 'py-1 pl-1 last:pr-1 -mr-1 last:mr-0',
   outlinedSelected: 'i-border-$color-buttongroup-utility-border-active',
-  selected: 'z-30 i-text-$color-buttongroup-utility-text-active! i-bg-$color-buttongroup-utility-background-active! hover:i-bg-$color-buttongroup-utility-background-active-hover!',
+  selected: 'z-30 i-text-$color-buttongroup-utility-text-active! i-bg-$color-buttongroup-utility-background-active!',
 }
 
 export const alert = {


### PR DESCRIPTION
Based on changes made in https://github.com/warp-ds/tokens/pull/56 we can remove respective classes that would apply the removed tokens.