### PR TITLE
fix(index.js): add remaining classes to alert object

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,6 +296,9 @@ export const modal = {
 
 export const alert = {
   alert: "flex p-16 border border-l-4 rounded-4",
+  willChangeHeight: "will-change-height",
+  textWrapper: "last-child:mb-0 text-s",
+  title: "font-bold",
   icon: "w-16 mr-8 min-w-16",
   negative:  "i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border",
   negativeIcon: "i-text-$color-alert-negative-icon",


### PR DESCRIPTION
Some Alert classes were still used inline in all 3 frameworks, which caused them to not be picked up by unocss inside shadow DOM. With them being added to the `alert` object in this PR, the problem will be fixed.

Also:
- updated `last:mb-0` to `last-child:mb-0` as this will be the correct utility class for a parent element.
- used a corresponding `text-s` class instead of `text-14` as this will probably be the preferred way of using text- utility classes (though both versions are supported at the moment)