### PR TITLE
fix: should be last for the box wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ export const slider = {
 };
 
 export const box = {
-  box: 'group block relative break-words last-child:mb-0 p-16 rounded-8', // Relative here enables w-clickable
+  box: 'group block relative break-words last:mb-0 p-16 rounded-8', // Relative here enables w-clickable
   bleed: '-mx-16 sm:mx-0 rounded-l-0 rounded-r-0 sm:rounded-8', // We target L and R to override the default rounded-8
   info: 'i-bg-$color-box-info-background',
   neutral: 'i-bg-$color-box-neutral-background',


### PR DESCRIPTION
I made mistake in my previous PR 🤦 

Before|After
---|---
![image](https://github.com/warp-ds/component-classes/assets/37986637/074f7932-00e7-4900-8633-49f6c8486643)|![image](https://github.com/warp-ds/component-classes/assets/37986637/873b2692-3801-410c-ac75-6799416bd831)
