### PR TITLE
fix: align suffix and prefix for input

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,20 +343,20 @@ export const helpText = {
 }
 
 const prefixSuffixWrapperBase =
-  'absolute top-0 bottom-0 hover:text-aqua-400 flex justify-center items-center focusable ';
+  'absolute top-0 bottom-0 flex justify-center items-center focusable ';
 
 export const suffix = {
   wrapper: prefixSuffixWrapperBase + 'right-0',
   wrapperWithLabel: 'w-max pr-12',
   wrapperWithIcon: 'w-40',
-  label: `${label.label} pb-0 text-12`,
+  label: `${label.label} pb-0! text-12!`,
 };
 
 export const prefix = {
   wrapper: prefixSuffixWrapperBase + 'left-0',
   wrapperWithLabel: 'w-max pl-12',
   wrapperWithIcon: 'w-40',
-  label: `${label.label} pb-0 text-secondary text-12`,
+  label: `${label.label} pb-0! text-12!`,
 };
 
 export const breadcrumbs = {


### PR DESCRIPTION
Before|After
---|---
![image](https://github.com/warp-ds/component-classes/assets/37986637/227bc02b-6931-4616-902f-d1aabbbbe44e)|![image](https://github.com/warp-ds/component-classes/assets/37986637/ca454a60-2be6-450f-a3f1-01d1be6a6cc2)
