### PR TITLE
fix(index.js): add bg-transparent to clickableNotToggle

### DIFF
--- a/index.js
+++ b/index.js
@@ -411,7 +411,7 @@ export const toggle = {
 
 export const clickable = {
   clickable: 'absolute inset-0 h-full w-full appearance-none cursor-pointer focusable focusable-inset',
-  clickableNotToggle: 'inset-0 absolute',
+  clickableNotToggle: 'inset-0 absolute bg-transparent',
   label: `px-12 ${label.label} py-8! cursor-pointer focusable focusable-inset`, 
 }
 


### PR DESCRIPTION
This change could be used in @warp-ds/react right away. Later we'll import component-classes from @warp-ds/css so a corresponding change was made there: https://github.com/warp-ds/css/pull/29

Before:
![Screenshot 2023-07-06 at 09 09 21](https://github.com/warp-ds/css/assets/41303231/35c8f6cf-23d0-4913-963a-2bf0213953ff)

After:
![Screenshot 2023-07-06 at 09 09 13](https://github.com/warp-ds/css/assets/41303231/2c28553e-5f8d-49bb-8bdd-517214742bca)